### PR TITLE
Add DiagnosticsLogger tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,16 @@ The control computer communicates with the Raspberry Pis via SSH to start and mo
 - Check the diagnostic logs on the Raspberry Pis and the control computer for any error messages or warnings.
 - Ensure that all the required libraries and dependencies are installed correctly on the Raspberry Pis and the control computer.
 
+## Running Tests
+
+The project includes automated tests built with `pytest`. Run the entire test suite from the repository root with:
+
+```bash
+pytest
+```
+
+This command executes all tests, including diagnostics logging checks.
+
 ## Contributing
 
 Contributions to this project are welcome. If you find any issues or have suggestions for improvements, please open an issue or submit a pull request on the project repository.

--- a/tests/test_diagnostics_logger.py
+++ b/tests/test_diagnostics_logger.py
@@ -1,0 +1,32 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for the Flask jsonify function
+flask_stub = types.ModuleType("flask")
+flask_stub.jsonify = lambda **kwargs: kwargs
+sys.modules.setdefault("flask", flask_stub)
+
+from home.diagnostics import DiagnosticsLogger
+
+
+def test_diagnostics_logger_logs_and_get_logs(tmp_path):
+    log_file = tmp_path / "diag.log"
+    logger = DiagnosticsLogger(str(log_file))
+
+    logger.start_logging()
+    logger.log_frame_processing_time()
+    logger.stop_logging()
+
+    contents = log_file.read_text()
+    assert "Diagnostics logging started." in contents
+    assert "Diagnostics logging stopped." in contents
+
+    data = logger.get_logs()
+    log_text = "\n".join(data["logs"])
+    assert "Diagnostics logging started." in log_text
+    assert "Diagnostics logging stopped." in log_text
+    assert len(data["frame_processing_times"]) == 1


### PR DESCRIPTION
## Summary
- add pytest covering DiagnosticsLogger log writing and retrieval
- document how to run the test suite with pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a894a66d748329b0f46ccb25d496d2